### PR TITLE
Publish 0.1.0 to nuget

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,15 +28,15 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: cxnqT81ROTppRqe38gj69DWR//0h3h3+54voUvyu/uC3nqCbqQIzd4tp8ZF3p9Q/-
+    secure: 8LAREyPHSBeyFR6E3y6pxPex/RtJAyhDzPsnDpqk4NTHlXzU7ta+Kr90MAZksjHd
   skip_symbols: true
   on:
     branch: /^(master|dev)$/
     CI_WINDOWS: true
 - provider: GitHub
   auth_token:
-    secure: g3OuAhKEQrlw42xRckTIVFfd3RWLlJ+J6v0gDL1vARSFRnnvxNKTYmwwzeCHk2cG
-  artifact: Kmd.Logic.CitizenDocuments.*\.nupkg/
+    secure: XlVuF3nK3abb37/VzEjAmJLnGCr2KLFVE/G9gTHHu0AAGYlPi0GzPBFq+X/wLahp
+  artifact: Kmd.Logic.CitizenDocuments.Client*\.nupkg/
   tag: v$(appveyor_build_version)
   on:
     branch: master


### PR DESCRIPTION
* Includes cb0e19e - use new secure appveyor keys for nuget and github